### PR TITLE
Simplify chrome: drop frame/corners, center name, add theme toggle

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,15 +13,20 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0a0a0a" />
+    <script>
+        try {
+            if (localStorage.getItem('theme') === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body>
-    <div class="frame"></div>
-
-    <a class="corner corner-tl" href="/">BEN AUSTIN</a>
-    <span class="corner corner-tr">404</span>
+    <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to light mode"></button>
 
     <div class="scroll">
         <main>
+            <div class="name">BEN AUSTIN</div>
             <div class="mark">&#10037;</div>
 
             <div class="label">ERROR &mdash; 404</div>
@@ -34,6 +39,33 @@
             </p>
         </main>
     </div>
+
+    <script>
+        (function () {
+            var root = document.documentElement;
+            var btn = document.getElementById('theme-toggle');
+
+            function sync() {
+                var isLight = root.getAttribute('data-theme') === 'light';
+                btn.textContent = isLight ? '☾' : '☀';
+                btn.setAttribute('aria-label', isLight ? 'Switch to dark mode' : 'Switch to light mode');
+            }
+
+            btn.addEventListener('click', function () {
+                var isLight = root.getAttribute('data-theme') === 'light';
+                if (isLight) {
+                    root.removeAttribute('data-theme');
+                    try { localStorage.setItem('theme', 'dark'); } catch (e) {}
+                } else {
+                    root.setAttribute('data-theme', 'light');
+                    try { localStorage.setItem('theme', 'light'); } catch (e) {}
+                }
+                sync();
+            });
+
+            sync();
+        })();
+    </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,13 @@
     <meta charSet="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0a0a0a" />
+    <script>
+        try {
+            if (localStorage.getItem('theme') === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        } catch (e) {}
+    </script>
 </head>
 <body>
     <div class="loader" aria-hidden="true">
@@ -21,15 +28,11 @@
         <span class="loader-text">BEN AUSTIN</span>
     </div>
 
-    <div class="frame"></div>
-
-    <a class="corner corner-tl" href="#top">BEN AUSTIN</a>
-    <span class="corner corner-tr">SOFTWARE&nbsp;ENGINEER</span>
-    <a class="corner corner-bl" href="https://www.linkedin.com/in/benjaminaaustin/">LINKEDIN &#8599;</a>
-    <a class="corner corner-br" href="mailto:hello@benaustin.ca">EMAIL &#8599;</a>
+    <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Switch to light mode"></button>
 
     <div class="scroll">
         <main id="top">
+            <div class="name">BEN AUSTIN</div>
             <div class="mark">&#10037;</div>
 
             <div class="label">01 &mdash; ABOUT</div>
@@ -54,13 +57,35 @@
                 Get in touch at <a class="link" href="mailto:hello@benaustin.ca">hello@benaustin.ca</a>
                 or on <a class="link" href="https://www.linkedin.com/in/benjaminaaustin/">LinkedIn</a>.
             </p>
-
-            <div class="footer-links">
-                <a href="https://www.linkedin.com/in/benjaminaaustin/">LINKEDIN &#8599;</a>
-                <a href="mailto:hello@benaustin.ca">EMAIL &#8599;</a>
-            </div>
         </main>
     </div>
+
+    <script>
+        (function () {
+            var root = document.documentElement;
+            var btn = document.getElementById('theme-toggle');
+
+            function sync() {
+                var isLight = root.getAttribute('data-theme') === 'light';
+                btn.textContent = isLight ? '☾' : '☀';
+                btn.setAttribute('aria-label', isLight ? 'Switch to dark mode' : 'Switch to light mode');
+            }
+
+            btn.addEventListener('click', function () {
+                var isLight = root.getAttribute('data-theme') === 'light';
+                if (isLight) {
+                    root.removeAttribute('data-theme');
+                    try { localStorage.setItem('theme', 'dark'); } catch (e) {}
+                } else {
+                    root.setAttribute('data-theme', 'light');
+                    try { localStorage.setItem('theme', 'light'); } catch (e) {}
+                }
+                sync();
+            });
+
+            sync();
+        })();
+    </script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,14 @@
     --frame: 28px;
 }
 
+:root[data-theme="light"] {
+    --bg: #f5f4f2;
+    --fg: #111111;
+    --dim: rgba(17, 17, 17, 0.55);
+    --line: rgba(17, 17, 17, 0.14);
+    --accent: #3f6b3c;
+}
+
 * {
     box-sizing: border-box;
 }
@@ -37,18 +45,10 @@ body {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    transition: background-color .3s ease, color .3s ease;
 }
 
-/* hairline frame around the viewport, year0001-style */
-.frame {
-    position: fixed;
-    inset: var(--frame);
-    border: 1px solid var(--line);
-    pointer-events: none;
-    z-index: 3;
-}
-
-/* scroll happens inside the frame, content never crosses the top/bottom lines */
+/* scroll happens inside the viewport, content never crosses the top/bottom edges */
 .scroll {
     position: fixed;
     inset: var(--frame);
@@ -62,36 +62,24 @@ body {
     justify-content: safe center;
 }
 
-.corner {
+.theme-toggle {
     position: fixed;
+    top: 44px;
+    right: 48px;
     z-index: 4;
-    font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
-    color: var(--dim);
-    text-decoration: none;
     background: var(--bg);
+    border: none;
     padding: 6px;
     margin: -6px;
+    color: var(--dim);
+    font-size: 15px;
+    line-height: 1;
+    cursor: pointer;
     transition: color .25s ease;
 }
 
-.corner:hover {
+.theme-toggle:hover {
     color: var(--accent);
-}
-
-.corner::before {
-    display: none;
-}
-
-.corner-tl { top: 44px; left: 48px; }
-.corner-tr { top: 44px; right: 48px; }
-.corner-bl { bottom: 44px; left: 48px; }
-.corner-br { bottom: 44px; right: 48px; }
-
-.footer-links {
-    display: none;
 }
 
 main {
@@ -99,6 +87,15 @@ main {
     width: 100%;
     margin: 0 auto;
     padding: 64px 24px;
+}
+
+.name {
+    text-align: center;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.2em;
+    color: var(--dim);
+    margin-bottom: 40px;
 }
 
 .mark {
@@ -168,16 +165,9 @@ a.link:hover::before {
         --frame: 14px;
     }
 
-    .corner {
-        font-size: 9px;
-    }
-
-    .corner-tl, .corner-tr { top: 26px; }
-    .corner-tl, .corner-bl { left: 26px; }
-    .corner-tr, .corner-br { right: 26px; }
-
-    .corner-bl, .corner-br {
-        display: none;
+    .theme-toggle {
+        top: 26px;
+        right: 26px;
     }
 
     main {
@@ -186,19 +176,6 @@ a.link:hover::before {
 
     h1 {
         font-size: 30px;
-    }
-
-    .footer-links {
-        display: flex;
-        justify-content: space-between;
-        margin-top: 56px;
-        font-size: 11px;
-        letter-spacing: 0.16em;
-    }
-
-    .footer-links a {
-        color: var(--dim);
-        text-decoration: none;
     }
 }
 


### PR DESCRIPTION
## Summary
- Removes the hairline frame border and all four corner-pinned nav labels (SOFTWARE ENGINEER, LinkedIn/Email buttons, the BEN AUSTIN corner link) for a cleaner, less busy layout. Contact links already live inline in the CONTACT section, so nothing is lost.
- Adds a centered "BEN AUSTIN" name above the body content in place of the old corner label.
- Adds a small fixed sun/moon button that toggles a light theme via a `data-theme` attribute and CSS variable overrides, persisted in `localStorage`. An inline head script applies the stored theme before first paint to avoid a flash of the wrong theme.
- Applied consistently to both `index.html` and `404.html`.

## Test plan
- [x] Verified desktop layout with frame/corners removed and name centered
- [x] Verified light/dark theme toggle switches instantly and persists across reload (no flash of wrong theme)
- [x] Verified mobile viewport (375x812) — no overlap issues since fixed corner elements are gone